### PR TITLE
Create setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Check for the package manager
+if command -v apt &> /dev/null; then
+    # Debian/Ubuntu
+    sudo apt update -y
+    sudo apt install g++ -y
+elif command -v pacman &> /dev/null; then
+    # Arch Linux
+    sudo pacman -Syu --noconfirm
+    sudo pacman -S gcc --noconfirm
+elif command -v dnf &> /dev/null; then
+    # Fedora
+    sudo dnf update
+    sudo dnf install gcc-c++
+elif command -v yum &> /dev/null; then
+    # RHEL/CentOS
+    sudo yum update
+    sudo yum install gcc-c++
+else
+    echo -e "\e[31mUnsupported package manager! Please Install g++ for your Linux Distro!\e[0m"
+    exit 1
+fi
+
+# Adding the binary to /bin and making it executable
+echo -e "\e[32m[INFO] Installing the c-coderunner script."
+sudo cp crun /bin/
+sudo chmod +x /bin/crun
+echo -e "[INFO] Script installation successful."
+echo -e "Just type \e[31mrrun \e[33mfile_name.rs\e[32m and the code-runner script would run!!\e[0m"


### PR DESCRIPTION
Added the `setup.sh` file for `crun` c coderunner that installs the `g++` compiler if it is not present in the system and adds the binary to `/bin` and makes it executable.